### PR TITLE
Add climate and air quality sections to HTML reports

### DIFF
--- a/HTMLReportGenerator.R
+++ b/HTMLReportGenerator.R
@@ -47,6 +47,37 @@ reports_dir <- normalizePath(
   autoepi_settings$IO$Reports_Dir, winslash = "/", mustWork = FALSE)
 
 # ------------------------------------------------------------------
+# Helper functions for rendering external data
+# ------------------------------------------------------------------
+
+create_climate_section <- function(dat) {
+  if (is.null(dat) || nrow(dat) == 0) return("")
+  inner <- apply(dat, 1, function(row) {
+    glue(
+      "<h4>For station: {row['Station']}</h4>",
+      "<table class=\"data-table\">",
+      "<tr><th>MaxTemp</th><td>{row['MaxTemp']}</td></tr>",
+      "<tr><th>MinTemp</th><td>{row['MinTemp']}</td></tr>",
+      "<tr><th>AvgTemp</th><td>{row['AvgTemp']}</td></tr>",
+      "<tr><th>Water (rain)</th><td>{row['Water']}</td></tr>",
+      "<tr><th>Snow</th><td>{row['Snow']}</td></tr>",
+      "</table>"
+    )
+  })
+  glue('<div class="section"><h3>Climate</h3>{paste(inner, collapse = "")}</div>')
+}
+
+create_aqi_section <- function(dat, county) {
+  if (is.null(dat)) return("")
+  table_rows <- glue('<tr><td>{dat$Date}</td><td>{dat$Value}</td></tr>')
+  glue(
+    '<div class="section"><h3>Air Quality - {county} County</h3>',
+    '<table class="data-table"><tr><th>Date</th><th>PM2.5 24 hour Average</th></tr>',
+    '{table_rows}</table></div>'
+  )
+}
+
+# ------------------------------------------------------------------
 # 2.  HTML Template Functions
 # ------------------------------------------------------------------
 
@@ -311,10 +342,16 @@ for (i in seq_len(nrow(report_combinations))) {
   alert_level <- if (nrow(syndrome_data) > 10) "HIGH" else if (nrow(syndrome_data) > 5) "MEDIUM" else "LOW"
   
   # Generate HTML content
+  date_key <- as.character(date)
   html_content <- paste0(
     html_header(syndrome, date, alert_level),
     create_summary_section(syndrome_data, date),
     create_visualization_section(syndrome, date, autoepi_report),
+    if (isTRUE(autoepi_settings$Report_Settings$Climate$Include))
+      create_climate_section(autoepi_report[[date_key]]$meta$climate) else "",
+    if (isTRUE(autoepi_settings$Report_Settings$Air_Quality$enabled))
+      create_aqi_section(autoepi_report[[date_key]]$meta$air_quality,
+                         autoepi_settings$Report_Settings$Air_Quality$county) else "",
     html_footer()
   )
   

--- a/ReportCreator.R
+++ b/ReportCreator.R
@@ -54,6 +54,68 @@ ess_txt <- function(u)
   httr::content(httr::GET(u, authenticate(usr, pwd)),
                 as = "text", encoding = "UTF-8")
 
+# --- External data helpers --------------------------------------------------
+# Mapping of station IDs to human-readable names
+CLIMATE_STATIONS <- c(
+  "pdt-eln" = "Ellensburg, Washington",
+  "otx-lws" = "Lewiston, Idaho",
+  "pdt-dls" = "Dallesport, Washington",
+  "pdt-psc" = "Pasco, Washington",
+  "sew-sew" = "Seattle, Washington",
+  "otx-geg" = "Spokane, Washington",
+  "pqr-vuo" = "Vancouver, Washington",
+  "pdt-alw" = "Walla Walla, Washington",
+  "otx-eat" = "Wenatchee, Washington",
+  "pdt-ykm" = "Yakima, Washington",
+  "sew-olm" = "Olympia, Washington",
+  "otx-omk" = "Omak, Washington",
+  "sew-bli" = "Bellingham, Washington",
+  "otx-dew" = "Deer Park, Washington"
+)
+
+fetch_climate_data <- function(date, station_ids) {
+  if (length(station_ids) == 0) return(NULL)
+  factors <- c("maxtemp", "mintemp", "avgtemp", "precip", "snow")
+  names_map <- c(maxtemp = "MaxTemp", mintemp = "MinTemp",
+                 avgtemp = "AvgTemp", precip = "Water", snow = "Snow")
+  station_param <- paste0("&stationID=", station_ids, collapse = "")
+
+  data_list <- lapply(factors, function(fct) {
+    url <- glue(
+      "https://essence.syndromicsurveillance.org/nssp_essence/api/dataDetails",
+      "?percentParam=noPercent&endDate={fmt_api(date)}&userId=5629",
+      "&weatherFactor={fct}&datasource=va_weather_aggr&stationAggregateFunc=max",
+      "&timeResolution=daily&aqtTarget=DataDetails&detector=probrepswitch",
+      "&timeAggregateFunc=max&startDate={fmt_api(date)}&refValues=true{station_param}"
+    )
+    js <- fromJSON(ess_txt(url), flatten = TRUE)$dataDetails
+    if (is.null(js)) return(tibble())
+    tibble(Station = js$stationID, value = js$value) %>%
+      mutate(variable = names_map[[fct]])
+  })
+
+  df <- bind_rows(data_list) %>%
+    tidyr::pivot_wider(names_from = variable, values_from = value) %>%
+    mutate(Station = CLIMATE_STATIONS[Station])
+
+  df
+}
+
+fetch_air_quality_data <- function(date, county) {
+  if (!nzchar(county)) return(NULL)
+  county_param <- paste0(tolower(county), ",%20wa")
+  url <- glue(
+    "https://essence.syndromicsurveillance.org/nssp_essence/api/dataDetails",
+    "?percentParam=noPercent&endDate={fmt_api(date)}&airQualityParameterName=pm2.5-24hr",
+    "&County={county_param}&userId=5629&datasource=airquality",
+    "&stationAggregateFunc=max&timeResolution=daily&aqtTarget=DataDetails",
+    "&detector=probrepswitch&timeAggregateFunc=max&startDate={fmt_api(date)}&refValues=true"
+  )
+  js <- fromJSON(ess_txt(url), flatten = TRUE)$dataDetails
+  if (is.null(js)) return(NULL)
+  tibble(Date = as.character(date), Value = js$value)
+}
+
 # --- Age bins (from settings) -----------------------------------------------
 age_binner <- (function() {
   s <- rep_set$Age_Group_Stratification
@@ -143,7 +205,7 @@ store <- function(dk, sk, sect, nm, obj) {
 
 for (d in sort(unique(reports_df$ObvsDate))) {
   dk   <- as.character(d)
-  reports[[dk]] <- list()
+  reports[[dk]] <- list(meta = list())
   rep_d  <- filter(reports_df, ObvsDate == d)
   denom_d <- filter(all_visits, ObvsDate == d)
   
@@ -315,6 +377,13 @@ for (d in sort(unique(reports_df$ObvsDate))) {
         store(dk, sk, "maps", "choropleth", m)
       }
     }
+  }
+
+  if (rep_set$Climate$Include) {
+    reports[[dk]]$meta$climate <- fetch_climate_data(d, rep_set$Climate$Station_IDs)
+  }
+  if (rep_set$Air_Quality$enabled) {
+    reports[[dk]]$meta$air_quality <- fetch_air_quality_data(d, rep_set$Air_Quality$county)
   }
 }
 


### PR DESCRIPTION
## Summary
- Fetch climate and air quality datasets during comprehensive report creation
- Render pre-fetched climate and PM2.5 tables in individual HTML reports

